### PR TITLE
Match any domain under ixl.com instead of just ca.ixl.com

### DIFF
--- a/userscript.js
+++ b/userscript.js
@@ -4,7 +4,7 @@
 // @version      6.1
 // @license CC-BY NC
 // @description  Sends HTML and canvas data to GPT-4o for math problem solving with enhanced accuracy, GUI, and auto-answering functionality
-// @match        https://ca.ixl.com/*
+// @match        https://*.ixl.com/*
 // @grant        GM_xmlhttpRequest
 // @grant        GM_addStyle
 // ==/UserScript==


### PR DESCRIPTION
Triggers the script from any subdomain of [ixl.com](https://ixl.com) rather than just [ca.ixl.com](https://ca.ixl.com). Which Fixes the script for users outside Canada.